### PR TITLE
[feat] 공통컴포넌트 프로필이미지 작업

### DIFF
--- a/src/components/ProfileImage.tsx
+++ b/src/components/ProfileImage.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { css } from '@emotion/react';
+
+type ProfileImageProps = {
+  src: string;
+  alt: string;
+  size?: 'sm' | 'md' | 'lg';
+};
+
+const sizes = {
+  sm: 32,
+  md: 48,
+  lg: 96
+};
+
+const ProfileImage: React.FC<ProfileImageProps> = ({ src, alt, size = 'md' }) => (
+  <div
+    css={css`
+      width: ${sizes[size]}px;
+      height: ${sizes[size]}px;
+      border-radius: 50%;
+      overflow: hidden;
+      display: inline-block;
+    `}
+  >
+    <img
+      src={src}
+      alt={alt}
+      css={css`
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      `}
+    />
+  </div>
+);
+
+export default ProfileImage;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

공통컴포넌트 프로필이미지 작업

## 📋 작업 내용

공통컴포넌트 프로필이미지 작업진행했는데 처음하는 방식이라 틀렸을 수 있으니 피드백 부탁드립니다!
임시로 다른 페이지에서 사이즈 잘 잡히는지 동작해봤습니다.

- Components 폴더 생성 후 ProfileImage 파일 생성
- 현재 피그마에 올라온 48, 96 외에 임시로 32 도 사이즈 추가해놓음

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

기능이 없이 그냥 프로필 사이즈만 있는 것 같아서 이렇게 작업했는데
추가해야할 부분 있다면 피드백 부탁드립니다.
