### PR TITLE
[feat] Tag 컴포넌트 구현

### DIFF
--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -12,7 +12,6 @@ const Tag: React.FC<TagProps> = ({ src, alt }) => (
 const tagStyle = css`
   display: inline-block;
   height: 16px;
-  margin: 0 2px;
 `;
 
 export default Tag;

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -1,0 +1,18 @@
+import { css } from '@emotion/react';
+
+interface TagProps {
+  src: string;
+  alt?: string;
+}
+
+const Tag: React.FC<TagProps> = ({ src, alt }) => (
+  <img css={tagStyle} src={src} alt={alt ? alt : 'tag'} />
+);
+
+const tagStyle = css`
+  display: inline-block;
+  height: 16px;
+  margin: 0 2px;
+`;
+
+export default Tag;

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { Link } from 'react-router-dom';
 import logo from '@/assets/images/logo.png';
-import COLOR from '@/constants/color';
+import { COLOR } from '@/constants/color';
 import { FONT_WEIGHT } from '@/constants/font';
 import { PATH } from '@/constants/path';
 
@@ -41,7 +41,7 @@ const headerTopBgStyle = css`
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: ${COLOR.PRIMARY_NORMAL};
+  background-color: ${COLOR.PRIMARY};
 `;
 
 const headerTopStyle = css`


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

Tag 컴포넌트 구현

## 📋 작업 내용

- Tag 컴포넌트 구현

## 📸 스크린샷 (선택 사항)

![ex](https://github.com/user-attachments/assets/241c1745-bc14-4375-881c-dd170e05cc81)

## 📄 기타

기본적으로 ProfileImage 컴포넌트와 유사하게 props 값으로 src, alt(선택사항)를 전달 받습니다.
프로젝트 내에서 사용하는 태그의 크기는 높이 16px로 정해져 있어, 단일 사이즈로 고정했습니다.
이후에 추가적인 수정 사항이 생기면 반영 예정입니다.