### PR TITLE
[feat] RadioButton 컴포넌트 구현

### DIFF
--- a/src/components/RadioButton.tsx
+++ b/src/components/RadioButton.tsx
@@ -20,9 +20,9 @@ const RadioButton: React.FC<RadioBtnProps> = ({
   selected,
   onChange,
 }) => (
-  <>
+  <div css={radioWrapperStyle}>
     {options.map((option) => (
-      <label key={option.value} css={labelWrapperStyle}>
+      <label key={option.value} css={labelStyle}>
         <div>
           <input
             type='radio'
@@ -34,15 +34,22 @@ const RadioButton: React.FC<RadioBtnProps> = ({
         {option.label}
       </label>
     ))}
-  </>
+  </div>
 );
 
-const labelWrapperStyle = css`
+const radioWrapperStyle = css`
+  display: flex;
+  gap: 16px;
+`;
+
+const labelStyle = css`
   display: flex;
   align-items: center;
   font-size: ${FONT_SIZE.TEXT_MD};
   font-weight: ${FONT_WEIGHT.REGULAR};
   letter-spacing: -0.32px;
+  cursor: pointer;
+
   div {
     border-radius: 50%;
     &:hover {
@@ -50,11 +57,13 @@ const labelWrapperStyle = css`
       transition: 0.3s;
     }
   }
+
   input[type='radio'] {
     width: 20px;
     height: 20px;
     margin: 10px;
     accent-color: ${COLOR.PRIMARY};
+    cursor: pointer;
   }
 `;
 

--- a/src/components/RadioButton.tsx
+++ b/src/components/RadioButton.tsx
@@ -1,0 +1,61 @@
+import { css } from '@emotion/react';
+import { COLOR, COLOR_OPACITY } from '@/constants/color';
+import { FONT_SIZE, FONT_WEIGHT } from '@/constants/font';
+
+interface RadioOptionProps {
+  label: string;
+  value: string;
+}
+
+interface RadioBtnProps {
+  options: RadioOptionProps[];
+  name: string;
+  selected: string;
+  onChange: (value: string) => void;
+}
+
+const RadioButton: React.FC<RadioBtnProps> = ({
+  options,
+  name,
+  selected,
+  onChange,
+}) => (
+  <>
+    {options.map((option) => (
+      <label key={option.value} css={labelWrapperStyle}>
+        <div>
+          <input
+            type='radio'
+            name={name}
+            checked={selected === option.value}
+            onChange={() => onChange(option.value)}
+          />
+        </div>
+        {option.label}
+      </label>
+    ))}
+  </>
+);
+
+const labelWrapperStyle = css`
+  display: flex;
+  align-items: center;
+  font-size: ${FONT_SIZE.TEXT_MD};
+  font-weight: ${FONT_WEIGHT.REGULAR};
+  letter-spacing: -0.32px;
+  div {
+    border-radius: 50%;
+    &:hover {
+      background-color: ${COLOR_OPACITY.PRIMARY_OPACITY10};
+      transition: 0.3s;
+    }
+  }
+  input[type='radio'] {
+    width: 20px;
+    height: 20px;
+    margin: 10px;
+    accent-color: ${COLOR.PRIMARY};
+  }
+`;
+
+export default RadioButton;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**(공통 컴포넌트) 라디오 버튼 구현**

## 📋 작업 내용

- 라디오 버튼 구현
- 라디오 버튼 간의 gap 16px로 고정

## 📸 스크린샷 (선택 사항)
![radio](https://github.com/user-attachments/assets/738e0015-c210-470a-86db-9237b8f2fbf9)

## 📄 기타
사용방법
```
//상태 관리 변수
const [isChecked, setIsChecked] = useState('all');

//라디오 버튼의 label 및 value (필요한 개수 만큼 추가)
const options2 = [
    { label: '전체', value: 'all' },
    { label: '1년 이하', value: 'under1' },
    { label: '1년 ~ 2년', value: '1to2' },
    { label: '2년 ~ 3년', value: '2to3' },
    { label: '3년 이상', value: 'over3' },
  ] 

// 사용 예시
    <RadioButton
      name='agreeRadioBtn'
      options={options2}
      selected={isChecked}
      onChange={setIsChecked}
    />
```
- 체크 상태는 상태 관리 할 때, 초기 값 비워두지말고 선택 해놓을 default 값을 넣어줘야 함.
- 필요한 개수만큼 부모 컴포넌트에서 객체 배열로 label, value 관리
- name이 같은 라디오 버튼 끼리 한 세트
