### PR TITLE
[feat] TextArea 컴포넌트 구현

### DIFF
--- a/src/components/TextArea.tsx
+++ b/src/components/TextArea.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { COLOR_OPACITY } from '@/constants/color';
+import { COLOR, COLOR_OPACITY } from '@/constants/color';
 import { FONT_SIZE, FONT_WEIGHT } from '@/constants/font';
 
 type TextAreaTypes = 'default' | 'transparent';
@@ -57,7 +57,7 @@ const textAreaStyle = (
   border: 1px solid
     ${color === 'transparent' ? 'transparent' : COLOR_OPACITY.BLACK_OPACITY30};
   border-radius: 4px;
-  background-color: #fff;
+  background-color: ${COLOR.WHITE};
 
   &::placeholder {
     color: ${COLOR_OPACITY.BLACK_OPACITY30};

--- a/src/components/TextArea.tsx
+++ b/src/components/TextArea.tsx
@@ -1,0 +1,67 @@
+import { css } from '@emotion/react';
+import { COLOR_OPACITY } from '@/constants/color';
+import { FONT_SIZE, FONT_WEIGHT } from '@/constants/font';
+
+type TextAreaTypes = 'default' | 'transparent';
+
+interface TextAreaProps {
+  placeholder?: string;
+  value: string;
+  maxLength?: number;
+  color?: TextAreaTypes;
+  fullWidth?: boolean;
+  fullHeight?: boolean;
+  width?: number;
+  height?: number;
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+}
+
+const TextArea: React.FC<TextAreaProps> = ({
+  placeholder,
+  value,
+  maxLength = 500,
+  color = 'default',
+  fullWidth = false,
+  fullHeight = false,
+  width = 700,
+  height = 240,
+  onChange,
+}) => (
+  <textarea
+    css={textAreaStyle(color, fullWidth, fullHeight, width, height)}
+    placeholder={placeholder}
+    value={value}
+    maxLength={maxLength}
+    onChange={onChange}
+  />
+);
+
+const textAreaStyle = (
+  color: TextAreaTypes,
+  fullWidth: boolean,
+  fullHeight: boolean,
+  width: number,
+  height: number
+) => css`
+  width: ${fullWidth ? '100%' : width ? `${width}px` : 'auto'};
+  height: ${fullHeight ? '100%' : height ? `${height}px` : 'auto'};
+  padding: 16px;
+  resize: none;
+
+  font-size: ${FONT_SIZE.TEXT_SM};
+  font-weight: ${FONT_WEIGHT.REGULAR};
+  font-family: inherit;
+  letter-spacing: -0.28px;
+  line-height: 100%;
+
+  border: 1px solid
+    ${color === 'transparent' ? 'transparent' : COLOR_OPACITY.BLACK_OPACITY30};
+  border-radius: 4px;
+  background-color: #fff;
+
+  &::placeholder {
+    color: ${COLOR_OPACITY.BLACK_OPACITY30};
+  }
+`;
+
+export default TextArea;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**TextArea 컴포넌트 구현**

## 📋 작업 내용

TextArea 컴포넌트 구현

## 📸 스크린샷 (선택 사항)
![image](https://github.com/user-attachments/assets/6f4df950-8241-4029-ae0c-e1386a5abc23)


## 📄 기타
- 사용방법
  ![image](https://github.com/user-attachments/assets/710726e7-fd64-4fd0-9131-ec22b3422257)

- 기본값
피그마 전략소개 textArea 기준으로 default 처리. 
1. maxLength: 500
2. color(border-color): default (17,17,17,0.3)
3. width: 700px
4. height: 240px
5. fullWidth/fullHeight: false
  - fullWidth와 width, fullHeight와 height를 동시에 받지 않도록 주의
