### PR TITLE
[style] 전략 탐색 페이지 퍼블리싱 작업

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -70,11 +70,9 @@ const buttonColors: Record<ButtonColorTypes, ButtonColors> = {
 
 const buttonSizes: Record<ButtonSizeTypes, ReturnType<typeof css>> = {
   xs: css`
-    width: 120px;
     height: 32px;
   `,
   sm: css`
-    width: 144px;
     height: 40px;
   `,
   md: css`

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -4,14 +4,17 @@ import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import { COLOR, COLOR_OPACITY } from '@/constants/color';
 import { FONT_SIZE } from '@/constants/font';
 
+type SizeTypes = 'sm' | 'md' | 'lg';
 interface CheckboxProps {
   label?: string;
+  size?: SizeTypes;
   checked: boolean;
   handleChange: (checked: boolean) => void;
 }
 
 const Checkbox: React.FC<CheckboxProps> = ({
   label = '',
+  size = 'md',
   checked = false,
   handleChange,
 }) => {
@@ -21,7 +24,7 @@ const Checkbox: React.FC<CheckboxProps> = ({
 
   return (
     <div css={checkboxWrapperStyle}>
-      <div css={checkboxStyle} onClick={handleClick}>
+      <div css={checkboxStyle(size)} onClick={handleClick}>
         {checked ? (
           <CheckBoxIcon
             sx={{
@@ -52,8 +55,8 @@ const checkboxWrapperStyle = css`
   }
 `;
 
-const checkboxStyle = css`
-  margin: 4px;
+const checkboxStyle = (size: SizeTypes) => css`
+  margin: ${size === 'lg' ? '4px' : size === 'md' ? '2px' : '0px'};
   border-radius: 50%;
 
   svg {
@@ -62,7 +65,7 @@ const checkboxStyle = css`
     justify-content: center;
     font-size: ${FONT_SIZE.TITLE_SM};
     cursor: pointer;
-    margin: 8px;
+    margin: ${size === 'lg' ? '8px' : size === 'md' ? '6px' : '2px'};
   }
 
   :hover {

--- a/src/components/ProfileImage.tsx
+++ b/src/components/ProfileImage.tsx
@@ -21,8 +21,10 @@ const ProfileImage: React.FC<ProfileImageProps> = ({
 }) => (
   <div
     css={css`
-      width: ${sizes[size]}px;
-      height: ${sizes[size]}px;
+      min-width: ${sizes[size]}px;
+      min-height: ${sizes[size]}px;
+      max-width: ${sizes[size]}px;
+      max-height: ${sizes[size]}px;
       border-radius: 50%;
       overflow: hidden;
       display: inline-block;

--- a/src/components/RadioButton.tsx
+++ b/src/components/RadioButton.tsx
@@ -11,14 +11,14 @@ interface RadioBtnProps {
   options: RadioOptionProps[];
   name: string;
   selected: string;
-  onChange: (value: string) => void;
+  handleChange: (value: string) => void;
 }
 
 const RadioButton: React.FC<RadioBtnProps> = ({
   options,
   name,
   selected,
-  onChange,
+  handleChange,
 }) => (
   <div css={radioWrapperStyle}>
     {options.map((option) => (
@@ -28,7 +28,7 @@ const RadioButton: React.FC<RadioBtnProps> = ({
             type='radio'
             name={name}
             checked={selected === option.value}
-            onChange={() => onChange(option.value)}
+            onChange={() => handleChange(option.value)}
           />
         </div>
         {option.label}

--- a/src/components/TabButton.tsx
+++ b/src/components/TabButton.tsx
@@ -61,6 +61,7 @@ const tabWrapperStyle = (shape: ButtonShapeType) => css`
   position: relative;
   display: flex;
   gap: ${shape === 'round' ? '16px' : '0'};
+  width: 100%;
 `;
 
 const tabBtnStyle = css`
@@ -70,7 +71,6 @@ const tabBtnStyle = css`
   font-size: ${FONT_SIZE.TEXT_SM};
   font-weight: ${FONT_WEIGHT.MEDIUM};
   border: 0;
-  position: relative;
 
   :hover {
     cursor: pointer;
@@ -84,11 +84,10 @@ const tabBtnStyle = css`
     border-right: 1px solid ${COLOR.GRAY200};
 
     :hover {
-      background-color: ${COLOR.WHITE};
       color: ${COLOR.PRIMARY600};
-      border-top: 1px solid ${COLOR.WHITE};
-      border-left: 1px solid ${COLOR.WHITE};
-      border-right: 1px solid ${COLOR.WHITE};
+      border-top: 1px solid ${COLOR.GRAY200};
+      border-left: 1px solid ${COLOR.GRAY200};
+      border-right: 1px solid ${COLOR.GRAY200};
     }
 
     &.active {
@@ -103,8 +102,8 @@ const tabBtnStyle = css`
         display: block;
         position: absolute;
         bottom: -1px;
-        left: 100%;
-        width: calc(100vw - 90px);
+        right: 0;
+        width: calc(100% - 90px);
         height: 1px;
         background-color: ${COLOR.PRIMARY100};
       }

--- a/src/components/TextArea.tsx
+++ b/src/components/TextArea.tsx
@@ -13,7 +13,7 @@ interface TextAreaProps {
   fullHeight?: boolean;
   width?: number;
   height?: number;
-  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  handleChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
 }
 
 const TextArea: React.FC<TextAreaProps> = ({
@@ -25,14 +25,14 @@ const TextArea: React.FC<TextAreaProps> = ({
   fullHeight = false,
   width = 700,
   height = 240,
-  onChange,
+  handleChange,
 }) => (
   <textarea
     css={textAreaStyle(color, fullWidth, fullHeight, width, height)}
     placeholder={placeholder}
     value={value}
     maxLength={maxLength}
-    onChange={onChange}
+    onChange={handleChange}
   />
 );
 

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -20,7 +20,8 @@ interface InputProps {
   width?: number;
   iconNum?: InputIconNumTypes;
   value: string;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
 }
 
 const TextInput: React.FC<InputProps> = ({
@@ -32,14 +33,16 @@ const TextInput: React.FC<InputProps> = ({
   fullWidth = false,
   width = 360,
   iconNum = 'none',
-  onChange,
+  handleChange,
+  handleKeyDown,
 }) => (
   <>
     <input
       css={inputStyle(color, status, fullWidth, width, iconNum)}
       type={type}
       value={value}
-      onChange={onChange}
+      onChange={handleChange}
+      onKeyDown={handleKeyDown}
       placeholder={placeholder}
     />
   </>

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -21,6 +21,8 @@ export const PATH = {
   TRADER_STRATEGIES: (userId = ':userId') => `/strategies/traders/${userId}`,
   STRATEGIES_ADD_INFO: '/strategies/addInfo',
   STRATEGIES_ADD: '/strategies/add',
+  STRATEGIES_QNA: (strategyId = ':strategyId') =>
+    `/strategies/${strategyId}/qna`,
   MYPAGE: '/mypage',
   MYPAGE_PROFILE: (userId = ':userId') => `/mypage/${userId}/profile`,
   MYPAGE_PROFILE_EDIT: (userId = ':userId') => `/mypage/${userId}/profile/edit`,
@@ -34,7 +36,6 @@ export const PATH = {
   MYPAGE_CHECK: '/mypage/check',
   MYPAGE_WITHDRAW: '/mypage/withdraw',
   ADMIN: '/admin',
-  ADMIN_USERS: '/admin/users',
   ADMIN_NOTICES: '/admin/notices',
   ADMIN_NOTICES_ADD: '/admin/notices/add',
   ADMIN_NOTICES_EDIT: (noticeId = ':noticeId') =>

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -19,7 +19,6 @@ export const PATH = {
     `/strategies/${strategyId}/account`,
   ADD_QNA: (strategyId = ':strategyId') => `/strategies/${strategyId}/qna/add`,
   TRADER_STRATEGIES: (userId = ':userId') => `/strategies/traders/${userId}`,
-  STRATEGIES_ADD_INFO: '/strategies/addInfo',
   STRATEGIES_ADD: '/strategies/add',
   STRATEGIES_QNA: (strategyId = ':strategyId') =>
     `/strategies/${strategyId}/qna`,

--- a/src/layouts/StrategyListLayout.tsx
+++ b/src/layouts/StrategyListLayout.tsx
@@ -1,10 +1,93 @@
-import { Outlet } from 'react-router-dom';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import { css } from '@emotion/react';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
+import TabButton from '@/components/TabButton';
+import { COLOR } from '@/constants/color';
+import { PATH } from '@/constants/path';
 
-const StrategyListLayout = () => (
-  <div>
-    전략탐색목록 인덱스 페이지
-    <Outlet />
-  </div>
-);
+const TAB_NAME = ['전략 목록', '트레이더 목록'];
+
+const StrategyListLayout = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [currentTab, setCurrentTab] = useState(0);
+
+  useEffect(() => {
+    if (location.pathname.includes('/traders')) {
+      setCurrentTab(1);
+    } else {
+      setCurrentTab(0);
+    }
+  }, [location.pathname]);
+
+  // TabButton에 전달할 핸들러
+  const handleTabChange: Dispatch<SetStateAction<number>> = (value) => {
+    // value가 함수일 경우와 숫자일 경우를 모두 처리
+    const newIndex = typeof value === 'function' ? value(currentTab) : value;
+    setCurrentTab(newIndex);
+
+    if (newIndex === 0) {
+      navigate(PATH.STRATEGIES_LIST);
+    } else {
+      navigate(PATH.TRADERS);
+    }
+  };
+
+  return (
+    <div css={LayoutWrapperStyle}>
+      <section className='common-area'>
+        <div className='title'>
+          <h5>전략 탐색</h5>
+          <span>
+            시스메틱 트레이더에서 당신이 원하는 투자 상품을 찾아 보세요!
+            <br />
+            전략 목록을 통해 인기 있는 상품을 선택하거나, 전략 탐색을 통해
+            투자를 할 수도 있고, 실력 있는 트레이더를 선택하여 투자 기록을
+            확인할 수 있습니다.
+          </span>
+        </div>
+        <span className='line'></span>
+        <TabButton
+          tabs={TAB_NAME}
+          currentTab={currentTab}
+          handleTabChange={handleTabChange}
+        />
+      </section>
+      <Outlet />
+    </div>
+  );
+};
+
+const LayoutWrapperStyle = css`
+  max-width: 1200px;
+  width: 100%;
+  padding: 100px 10px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+
+  .common-area {
+    display: flex;
+    flex-direction: column;
+    gap: 40px;
+
+    .title {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+
+      span {
+        line-height: 160%;
+      }
+    }
+
+    .line {
+      width: 100%;
+      height: 1px;
+      background-color: ${COLOR.TEXT_BLACK};
+    }
+  }
+`;
 
 export default StrategyListLayout;

--- a/src/mocks/traders.json
+++ b/src/mocks/traders.json
@@ -1,0 +1,242 @@
+[
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 53,
+    "strategyCount": 26,
+    "nickname": "주식왕"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 69,
+    "strategyCount": 31,
+    "nickname": "금융멘토"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 39,
+    "strategyCount": 19,
+    "nickname": "투자대가"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 41,
+    "strategyCount": 35,
+    "nickname": "스탁매니저"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 60,
+    "strategyCount": 4,
+    "nickname": "주식고수"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 4,
+    "strategyCount": 32,
+    "nickname": "투자고수"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 85,
+    "strategyCount": 32,
+    "nickname": "주식바보"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 66,
+    "strategyCount": 24,
+    "nickname": "스톡픽"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 100,
+    "strategyCount": 7,
+    "nickname": "장기투자자"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 47,
+    "strategyCount": 6,
+    "nickname": "주식의신"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 59,
+    "strategyCount": 44,
+    "nickname": "주식연구소"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 77,
+    "strategyCount": 12,
+    "nickname": "스톡러너"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 5,
+    "strategyCount": 45,
+    "nickname": "주식왕국"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 63,
+    "strategyCount": 20,
+    "nickname": "트레이딩마스터"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 96,
+    "strategyCount": 48,
+    "nickname": "스톡매니아"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 27,
+    "strategyCount": 44,
+    "nickname": "주식토크"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 60,
+    "strategyCount": 18,
+    "nickname": "스탁라인"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 41,
+    "strategyCount": 35,
+    "nickname": "주식투자왕"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 96,
+    "strategyCount": 10,
+    "nickname": "장기투자자"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 90,
+    "strategyCount": 48,
+    "nickname": "주식헬퍼"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 45,
+    "strategyCount": 29,
+    "nickname": "투자멘토"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 25,
+    "strategyCount": 26,
+    "nickname": "금융트렌드"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 69,
+    "strategyCount": 31,
+    "nickname": "투자컨설턴트"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 53,
+    "strategyCount": 28,
+    "nickname": "스탁컴퍼니"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 95,
+    "strategyCount": 1,
+    "nickname": "주식지존"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 79,
+    "strategyCount": 3,
+    "nickname": "스톡소울"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 12,
+    "strategyCount": 2,
+    "nickname": "트레이딩백"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 82,
+    "strategyCount": 6,
+    "nickname": "스톡매니저"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 85,
+    "strategyCount": 48,
+    "nickname": "주식마스터"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 74,
+    "strategyCount": 35,
+    "nickname": "펀드매니저"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 85,
+    "strategyCount": 6,
+    "nickname": "스탁로드"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 69,
+    "strategyCount": 19,
+    "nickname": "투자미래"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 36,
+    "strategyCount": 9,
+    "nickname": "스탁딥"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 12,
+    "strategyCount": 43,
+    "nickname": "주식의길"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 3,
+    "strategyCount": 50,
+    "nickname": "주식명장"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 43,
+    "strategyCount": 27,
+    "nickname": "투자명장"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 64,
+    "strategyCount": 32,
+    "nickname": "금융매니저"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 55,
+    "strategyCount": 17,
+    "nickname": "스톡홀릭"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 22,
+    "strategyCount": 7,
+    "nickname": "펀드관리자"
+  },
+  {
+    "profileImage": "/src/assets/images/test-profile.png",
+    "interestCount": 52,
+    "strategyCount": 46,
+    "nickname": "주식트렌드"
+  }
+]

--- a/src/pages/StrategyAddInfo.tsx
+++ b/src/pages/StrategyAddInfo.tsx
@@ -1,3 +1,0 @@
-const StrategyAddInfo = () => <div>StrategyAddInfo</div>;
-
-export default StrategyAddInfo;

--- a/src/pages/StrategyList.tsx
+++ b/src/pages/StrategyList.tsx
@@ -1,3 +1,346 @@
-const StrategyList = () => <div>StrategyList</div>;
+import { useState } from 'react';
+import { css } from '@emotion/react';
+import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined';
+import Checkbox from '@/components/Checkbox';
+import RadioButton from '@/components/RadioButton';
+import TabButton from '@/components/TabButton';
+import TextInput from '@/components/TextInput';
+import { COLOR } from '@/constants/color';
+import { FONT_WEIGHT } from '@/constants/font';
+import {
+  AlgorithmFilterTypes,
+  FilterProps,
+  ItemFilterTypes,
+} from '@/types/strategyFilter';
+
+const TAB_NAME = ['항목별', '알고리즘별'];
+
+const TAB_FILTERS: { [key: number]: FilterProps[] } = {
+  0: [
+    {
+      id: 'operationMethod',
+      label: '운용 방식',
+      type: 'checkbox',
+      options: [
+        { value: 'manual', label: 'Manual Trading' },
+        { value: 'system', label: 'System Trading' },
+        { value: 'hybrid', label: 'Hybrid Trading (Manual + System)' },
+      ],
+    },
+    {
+      id: 'operationPeriod',
+      label: '운용 주기',
+      type: 'checkbox',
+      options: [
+        { value: 'day', label: '데이' },
+        { value: 'position', label: '포지션' },
+      ],
+    },
+    {
+      id: 'operationType',
+      label: '운용 종목',
+      type: 'checkbox',
+      options: [
+        { value: 'domesticStocks', label: '국내주식' },
+        { value: 'overseasStocks', label: '해외주식' },
+        { value: 'domesticEtf', label: '국내 ETF' },
+        { value: 'overseasEtf', label: '해외 ETF' },
+        { value: 'domesticBonds', label: '국내 채권' },
+        { value: 'overseasBonds', label: '해외 채권' },
+        { value: 'domesticRitz', label: '국내 리츠' },
+        { value: 'overseasRitz', label: '해외 리츠' },
+      ],
+    },
+    {
+      id: 'operationTerm',
+      label: '운용 기간',
+      type: 'radio',
+      options: [
+        { value: 'all', label: '전체' },
+        { value: 'lessThan1Year', label: '1년 이하' },
+        { value: '1To2Years', label: '1년 ~ 2년' },
+        { value: '2To3Years', label: '2년 ~ 3년' },
+        { value: 'moreThan3Years', label: '3년 이상' },
+      ],
+    },
+    {
+      id: 'profitRate',
+      label: '누적손익률',
+      type: 'radio',
+      options: [
+        // TODO: option 아직 미정. 추후 수정
+        { value: 'subAll', label: '전체' },
+        { value: 'subType1', label: '10% 이하' },
+        { value: 'subType2', label: '10% ~ 20%' },
+        { value: 'subType3', label: '30% 이상' },
+      ],
+    },
+  ],
+  1: [
+    {
+      id: 'algorithm',
+      label: '알고리즘',
+      type: 'radio',
+      options: [
+        { value: 'efficient', label: '효율형 전략' },
+        { value: 'offensive', label: '공격형 전략' },
+        { value: 'defensive', label: '방어형 전략' },
+      ],
+    },
+  ],
+};
+
+const StrategyList = () => {
+  const [currentTab, setCurrentTab] = useState(0);
+  const [searchValue, setSearchValue] = useState('');
+
+  // 상태 초기화
+  const [itemFilters, setItemFilters] = useState<ItemFilterTypes>({
+    operationMethod: ['manual', 'system', 'hybrid'],
+    operationPeriod: ['day', 'position'],
+    operationType: [
+      'domesticStocks',
+      'overseasStocks',
+      'domesticEtf',
+      'overseasEtf',
+      'domesticBonds',
+      'overseasBonds',
+      'domesticRitz',
+      'overseasRitz',
+    ],
+    operationTerm: 'all',
+    profitRate: 'subAll',
+  });
+
+  const [algorithmFilters, setAlgorithmFilters] =
+    useState<AlgorithmFilterTypes>({
+      algorithm: 'efficient',
+    });
+
+  const updateFilters = (
+    tabIndex: number,
+    id: string,
+    value: string | string[]
+  ) => {
+    if (tabIndex === 0) {
+      // itemFilters 업데이트
+      setItemFilters((prevFilters) => ({
+        ...prevFilters,
+        [id]: value,
+      }));
+    } else if (tabIndex === 1) {
+      // algorithmFilters 업데이트
+      setAlgorithmFilters((prevFilters) => ({
+        ...prevFilters,
+        [id]: value,
+      }));
+    }
+  };
+
+  const currentFilters = currentTab === 0 ? itemFilters : algorithmFilters;
+
+  const StrategyListFilter = ({
+    tabIndex,
+    currentFilters,
+    updateFilters,
+  }: {
+    tabIndex: number;
+    currentFilters: ItemFilterTypes | AlgorithmFilterTypes;
+    updateFilters: (
+      tabIndex: number,
+      id: string,
+      value: string | string[]
+    ) => void;
+  }) => {
+    const currentTabFilters = TAB_FILTERS[tabIndex];
+
+    const renderFilterInput = (filter: FilterProps) => {
+      switch (filter.type) {
+        case 'select':
+          return (
+            <select
+              value={
+                currentTab === 0
+                  ? itemFilters[filter.id as keyof ItemFilterTypes] || ''
+                  : algorithmFilters[filter.id as keyof AlgorithmFilterTypes] ||
+                    ''
+              }
+              onChange={(e) =>
+                updateFilters(currentTab, filter.id, e.target.value)
+              }
+            >
+              <option value='' disabled>
+                종목 선택
+              </option>
+              {filter.options?.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          );
+
+        case 'checkbox':
+          return (
+            <div css={checkboxGroupStyle}>
+              {filter.options?.map((option) => (
+                <Checkbox
+                  key={option.value}
+                  label={option.label}
+                  checked={(
+                    currentFilters[
+                      filter.id as keyof typeof currentFilters
+                    ] as string[]
+                  ).includes(option.value)}
+                  handleChange={(checked) => {
+                    const values = currentFilters[
+                      filter.id as keyof typeof currentFilters
+                    ] as string[];
+                    const updatedValues = checked
+                      ? [...values, option.value]
+                      : values.filter((v) => v !== option.value);
+                    updateFilters(currentTab, filter.id, updatedValues);
+                  }}
+                />
+              ))}
+            </div>
+          );
+
+        case 'radio':
+          return (
+            <RadioButton
+              options={filter.options || []}
+              name={filter.id}
+              selected={
+                currentFilters[filter.id as keyof typeof currentFilters] ||
+                filter.options?.[0]?.value ||
+                ''
+              }
+              handleChange={(value) =>
+                updateFilters(currentTab, filter.id, value)
+              }
+            />
+          );
+
+        default:
+          return null;
+      }
+    };
+
+    return (
+      <div css={filterContentStyle}>
+        {currentTabFilters.map((filter) => (
+          <div className='filter' key={filter.id}>
+            <label className='filter-label'>{filter.label}</label>
+            {renderFilterInput(filter)}
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <div css={strategyWrapperStyle}>
+      <section className='search-box-bg'>
+        <div className='search-box'>
+          <TextInput
+            type='text'
+            iconNum='single'
+            placeholder='전략명'
+            color='skyblue'
+            value={searchValue}
+            width={360}
+            handleChange={(e) => setSearchValue(e.target.value)}
+          />
+          <SearchOutlinedIcon />
+        </div>
+      </section>
+      <section css={filterStyle}>
+        <TabButton
+          tabs={TAB_NAME}
+          currentTab={currentTab}
+          shape='block'
+          handleTabChange={setCurrentTab}
+        />
+        <div className='filter-wrapper'>
+          <StrategyListFilter
+            tabIndex={currentTab}
+            currentFilters={currentFilters}
+            updateFilters={updateFilters}
+          />
+        </div>
+      </section>
+      <div>현재 필터: {JSON.stringify(currentFilters, null, 2)}</div>
+    </div>
+  );
+};
+
+const BG_COLOR = `#F1F7FE;`;
+
+const strategyWrapperStyle = css`
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+
+  .search-box-bg {
+    padding: 36px;
+    width: 100%;
+    border-radius: 2px;
+    display: flex;
+    justify-content: center;
+    border: 1px solid ${COLOR.PRIMARY100};
+    background-color: ${BG_COLOR};
+
+    .search-box {
+      position: relative;
+      svg {
+        position: absolute;
+        width: 48px;
+        height: 48px;
+        padding: 12px;
+        right: 0;
+        cursor: pointer;
+      }
+    }
+  }
+`;
+
+const filterStyle = css`
+  .filter-wrapper {
+    border-width: 0px 1px 1px 1px;
+    border-style: solid;
+    border-color: ${COLOR.PRIMARY100};
+    padding: 0 24px;
+  }
+`;
+
+const filterContentStyle = css`
+  .filter {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 8px 0;
+
+    &:not(:last-child)::after {
+      content: '';
+      position: absolute;
+      height: 1px;
+      width: 100%;
+      background-color: ${COLOR.GRAY400};
+      bottom: 0;
+    }
+
+    .filter-label {
+      font-weight: ${FONT_WEIGHT.BOLD};
+      min-width: 70px;
+    }
+  }
+`;
+
+const checkboxGroupStyle = css`
+  display: flex;
+  gap: 12px;
+`;
 
 export default StrategyList;

--- a/src/pages/StrategyQna.tsx
+++ b/src/pages/StrategyQna.tsx
@@ -1,0 +1,3 @@
+const StrategyQna = () => <div>StrategyQna</div>;
+
+export default StrategyQna;

--- a/src/pages/TraderList.tsx
+++ b/src/pages/TraderList.tsx
@@ -1,3 +1,284 @@
-const TraderList = () => <div>TraderList</div>;
+import { useEffect, useState } from 'react';
+import { css } from '@emotion/react';
+import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined';
+import { useNavigate } from 'react-router-dom';
+import Button from '@/components/Button';
+import Pagination from '@/components/Pagination';
+import ProfileImage from '@/components/ProfileImage';
+import TextInput from '@/components/TextInput';
+import { COLOR } from '@/constants/color';
+import { FONT_SIZE, FONT_WEIGHT } from '@/constants/font';
+import { PATH } from '@/constants/path';
+import traderData from '@/mocks/traders.json';
+
+const PAGE_SIZE = 10;
+
+interface TraderProps {
+  profileImage: string;
+  nickname: string;
+  interestCount: number;
+  strategyCount: number;
+}
+
+const TraderList = () => {
+  const navigate = useNavigate();
+  const [traderInfo, setTraderInfo] = useState<TraderProps[]>([]);
+  const [filteredTraderInfo, setFilteredTraderInfo] = useState<TraderProps[]>(
+    []
+  );
+  const [currentPage, setCurrentPage] = useState(0);
+  const [totalPage, setTotalPage] = useState(0);
+  const [searchValue, setSearchValue] = useState('');
+  const [searchedValue, setSearchedValue] = useState('');
+
+  useEffect(() => {
+    setTraderInfo(traderData);
+    setFilteredTraderInfo(traderData);
+    setTotalPage(Math.ceil(traderData.length / PAGE_SIZE));
+  }, []);
+
+  const handleSearch = () => {
+    setSearchedValue(searchValue);
+
+    let filtered;
+
+    if (searchValue === '') {
+      filtered = traderInfo;
+    } else {
+      const searchTerms = searchValue
+        .split(' ')
+        .map((term) => term.trim().toLowerCase());
+
+      filtered = traderInfo.filter((trader) =>
+        searchTerms.every((term) =>
+          trader.nickname.toLowerCase().includes(term)
+        )
+      );
+    }
+
+    setFilteredTraderInfo(filtered);
+    setTotalPage(Math.ceil(filtered.length / PAGE_SIZE));
+    setCurrentPage(0);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleSearch();
+    }
+  };
+
+  return (
+    <div css={traderyWrapperStyle}>
+      <section className='search-box-bg'>
+        <div className='search-box'>
+          <TextInput
+            type='text'
+            iconNum='single'
+            placeholder='닉네임'
+            color='skyblue'
+            value={searchValue}
+            width={360}
+            handleChange={(e) => setSearchValue(e.target.value)}
+            handleKeyDown={handleKeyDown}
+          />
+          <div className='searchIcon' onClick={handleSearch}>
+            <SearchOutlinedIcon />
+          </div>
+        </div>
+      </section>
+      <section css={contentsWrapper}>
+        <h6 className='info-text'>
+          총 <strong>{filteredTraderInfo.length}명</strong>의 트레이더를 보실 수
+          있습니다
+        </h6>
+        {filteredTraderInfo.length > 0 ? (
+          <div css={cardWrapper}>
+            {filteredTraderInfo
+              .slice(currentPage * PAGE_SIZE, (currentPage + 1) * PAGE_SIZE)
+              .map((profile, index) => (
+                <div
+                  key={index}
+                  className='card'
+                  onClick={() => navigate(PATH.TRADER_STRATEGIES())}
+                >
+                  <ProfileImage
+                    src={profile.profileImage}
+                    size='xl'
+                    alt='트레이더 이미지'
+                  />
+                  <div className='card-info'>
+                    <div className='card-info-top'>
+                      <div className='nickname-area'>
+                        <span>트레이더</span>
+                        <h6>{profile.nickname}</h6>
+                      </div>
+                      <Button
+                        size='xs'
+                        shape='round'
+                        label='전략정보'
+                        width={80}
+                        handleClick={() => navigate(PATH.TRADER_STRATEGIES())}
+                      />
+                    </div>
+                    <div className='card-info-btm'>
+                      <span className='option'>관심 수</span>
+                      <span>{profile.interestCount}</span>
+                      <span className='line'></span>
+                      <span className='option'>전략 수</span>
+                      <span>{profile.strategyCount}</span>
+                    </div>
+                  </div>
+                </div>
+              ))}
+          </div>
+        ) : (
+          <span css={emptyContents}>
+            <strong>‘{searchedValue}’</strong> 검색결과는 없습니다.
+          </span>
+        )}
+        {filteredTraderInfo.length > 0 && (
+          <Pagination
+            totalPage={totalPage}
+            currentPage={currentPage}
+            handlePageChange={setCurrentPage}
+          />
+        )}
+      </section>
+    </div>
+  );
+};
+
+const BG_COLOR = `#F1F7FE;`;
+
+const traderyWrapperStyle = css`
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+
+  .search-box-bg {
+    padding: 36px;
+    width: 100%;
+    border-radius: 2px;
+    display: flex;
+    justify-content: center;
+    border: 1px solid ${COLOR.PRIMARY100};
+    background-color: ${BG_COLOR};
+
+    .search-box {
+      position: relative;
+
+      .searchIcon {
+        position: absolute;
+        width: 48px;
+        height: 48px;
+        padding: 12px;
+        right: 0;
+        top: 50%;
+        transform: translateY(-50%);
+        display: flex;
+        align-items: center;
+        cursor: pointer;
+
+        svg {
+          font-size: ${FONT_SIZE.TITLE_SM};
+        }
+      }
+    }
+  }
+`;
+
+const contentsWrapper = css`
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+
+  .info-text {
+    font-weight: ${FONT_WEIGHT.REGULAR};
+
+    strong {
+      font-weight: ${FONT_WEIGHT.BOLD};
+    }
+  }
+`;
+
+const cardWrapper = css`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+
+  .card {
+    display: flex;
+    gap: 16px;
+    border-radius: 4px;
+    border: 1px solid ${COLOR.PRIMARY100};
+    padding: 24px;
+
+    :hover {
+      cursor: pointer;
+    }
+
+    .card-info {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      width: 100%;
+
+      .card-info-top {
+        display: flex;
+        justify-content: space-between;
+
+        .nickname-area {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+
+          span {
+            color: ${COLOR.PRIMARY};
+            font-size: 8px;
+          }
+        }
+
+        button {
+          font-size: ${FONT_SIZE.TEXT_SM};
+          background-color: ${COLOR.WHITE};
+          color: ${COLOR.PRIMARY};
+          border: 1px solid ${COLOR.PRIMARY};
+
+          :hover {
+            background-color: ${COLOR.PRIMARY600};
+            color: ${COLOR.WHITE};
+          }
+        }
+      }
+
+      .card-info-btm {
+        display: flex;
+        gap: 8px;
+
+        .line {
+          height: 100%;
+          width: 1.5px;
+          background-color: ${COLOR.GRAY};
+        }
+
+        .option {
+          color: ${COLOR.GRAY700};
+        }
+      }
+    }
+  }
+`;
+
+const emptyContents = css`
+  padding: 32px;
+  border-radius: 4px;
+  background: ${COLOR.GRAY100};
+  text-align: center;
+
+  strong {
+    font-weight: ${FONT_WEIGHT.BOLD};
+    color: ${COLOR.POINT};
+  }
+`;
 
 export default TraderList;

--- a/src/pages/admin/Admin.tsx
+++ b/src/pages/admin/Admin.tsx
@@ -1,3 +1,3 @@
-const Admin = () => <div>Admin</div>;
+const Admin = () => <div>Admin-회원관리페이지</div>;
 
 export default Admin;

--- a/src/pages/admin/AdminUsers.tsx
+++ b/src/pages/admin/AdminUsers.tsx
@@ -1,3 +1,0 @@
-const AdminUsers = () => <div>AdminUsers</div>;
-
-export default AdminUsers;

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -39,7 +39,6 @@ import SignUpDone from '@/pages/SignUpDone';
 import SignUpForm from '@/pages/SignUpForm';
 import SignUpType from '@/pages/SignUpType';
 import StrategyAdd from '@/pages/StrategyAdd';
-import StrategyAddInfo from '@/pages/StrategyAddInfo';
 import StrategyDetail from '@/pages/StrategyDetail';
 import StrategyDetailAccount from '@/pages/StrategyDetailAccount';
 import StrategyDetailDaily from '@/pages/StrategyDetailDaily';
@@ -134,10 +133,6 @@ const router = createBrowserRouter([
       {
         path: PATH.TRADER_STRATEGIES(),
         element: <TraderStrategyList />,
-      },
-      {
-        path: PATH.STRATEGIES_ADD_INFO,
-        element: <StrategyAddInfo />,
       },
       {
         path: PATH.STRATEGIES_ADD,

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -14,7 +14,6 @@ import AdminNotices from '@/pages/admin/AdminNotices';
 import AdminQna from '@/pages/admin/AdminQna';
 import AdminStocks from '@/pages/admin/AdminStocks';
 import AdminStrategies from '@/pages/admin/AdminStrategies';
-import AdminUsers from '@/pages/admin/AdminUsers';
 import Faq from '@/pages/Faq';
 import Home from '@/pages/Home';
 import MyPage from '@/pages/mypage/MyPage';
@@ -46,6 +45,7 @@ import StrategyDetailAccount from '@/pages/StrategyDetailAccount';
 import StrategyDetailDaily from '@/pages/StrategyDetailDaily';
 import StrategyDetailMonthly from '@/pages/StrategyDetailMonthly';
 import StrategyList from '@/pages/StrategyList';
+import StrategyQna from '@/pages/StrategyQna';
 import TraderList from '@/pages/TraderList';
 import TraderStrategyList from '@/pages/TraderStrategyList';
 
@@ -144,6 +144,10 @@ const router = createBrowserRouter([
         element: <StrategyAdd />,
       },
       {
+        path: PATH.STRATEGIES_QNA(),
+        element: <StrategyQna />,
+      },
+      {
         path: PATH.MYPAGE,
         element: <MyPageLayout />,
         children: [
@@ -196,10 +200,6 @@ const router = createBrowserRouter([
       {
         path: PATH.ADMIN,
         element: <Admin />,
-      },
-      {
-        path: PATH.ADMIN_USERS,
-        element: <AdminUsers />,
       },
       {
         path: PATH.ADMIN_NOTICES,

--- a/src/types/strategyFilter.ts
+++ b/src/types/strategyFilter.ts
@@ -1,0 +1,25 @@
+export type FilterTypes = 'select' | 'checkbox' | 'radio';
+
+export type ItemFilterTypes = {
+  operationMethod: string[];
+  operationPeriod: string[];
+  operationType: string[];
+  operationTerm: string;
+  profitRate: string;
+};
+
+export type AlgorithmFilterTypes = {
+  algorithm: string;
+};
+
+export interface FilterOptionProps {
+  value: string;
+  label: string;
+}
+
+export interface FilterProps {
+  id: string;
+  label: string;
+  type: FilterTypes;
+  options?: FilterOptionProps[];
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

전략 탐색 페이지 퍼블리싱 작업

## 📋 작업 내용

1. 전략 목록/트레이더 목록 페이지 퍼블리싱
- 공백포함 검색 처리 (예: '금  융' ---> '금융' 으로 검색)
- 항목별, 알고리즘별은 개별 로직. 탭 넘어가면 데이터 리셋
3. 자잘한 컴포넌트 수정
- 프로필 컴포넌트 일그러지는거 수정
- 탭버튼 컴포넌트 shape: block 일때 아래 선 어긋나는거 css 수정
- 버튼 컴포넌트에서 xs, sm 사이즈의 width가 지정되어 있어서, props로 width를 주면 우선순위에서 밀려서 적용이 안되는 이슈 수정
- textInput에 handleKeyDown 필요해서 추가
- 체크박스 사이즈 props 추가
4. 라우팅 수정
- 문의페이지 추가
- 관리자 메인을 회원관리로 변경
- add-info 삭제
5. 컴포넌트들 onChange->handleChange로 수정. 추후 각 페이지에 연결된 컴포넌트들 수정 해야함

## 📸 스크린샷 
![Nov-18-2024 13-21-29](https://github.com/user-attachments/assets/b2b47abf-fbdc-4aac-b37e-da1a29306496)

## 📄 기타
1. 라우팅 기타(서비스 이용약관, 개인정보처리방침, 회사소개) 페이지는 추후에 추가
2. 검색 버튼을 추가해 한번에 api를 요청할지, 값이 바뀔때마다 api를 요청할지 백엔드분과 논의중
3. 테이블 컴포넌트 구현 예정
4. mock 파일 추후 삭제 예정
5. 추후 로직 수정: 체크박스 ->선택안된 상태가 전체 선택
