### PR TITLE
[feat] RangeSlider 컴포넌트 구현

### DIFF
--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -9,6 +9,7 @@ interface CheckboxProps {
   label?: string;
   size?: SizeTypes;
   checked: boolean;
+  disabled?: boolean;
   handleChange: (checked: boolean) => void;
 }
 
@@ -16,38 +17,40 @@ const Checkbox: React.FC<CheckboxProps> = ({
   label = '',
   size = 'md',
   checked = false,
+  disabled = false,
   handleChange,
 }) => {
   const handleClick = () => {
-    handleChange(!checked);
+    if (!disabled) {
+      handleChange(!checked);
+    }
   };
 
   return (
-    <div css={checkboxWrapperStyle}>
-      <div css={checkboxStyle(size)} onClick={handleClick}>
-        {checked ? (
-          <CheckBoxIcon
-            sx={{
-              color: COLOR.WHITE,
-              fill: COLOR.PRIMARY,
-            }}
-          />
-        ) : (
-          <CheckBoxOutlineBlankIcon
-            sx={{
-              color: COLOR.GRAY800,
-            }}
-          />
-        )}
+    <div css={checkboxWrapperStyle(size)}>
+      <div css={checkboxBgStyle(size, disabled)} onClick={handleClick}>
+        <div css={checkboxStyle(disabled)}>
+          {checked ? (
+            <CheckBoxIcon
+              sx={{
+                color: COLOR.WHITE,
+                fill: COLOR.PRIMARY,
+              }}
+            />
+          ) : (
+            <CheckBoxOutlineBlankIcon className='blank' />
+          )}
+        </div>
       </div>
       {label && <span>{label}</span>}
     </div>
   );
 };
 
-const checkboxWrapperStyle = css`
+const checkboxWrapperStyle = (size: SizeTypes) => css`
   display: flex;
   align-items: center;
+  gap: ${size === 'sm' ? '4px' : ''};
 
   span {
     font-size: ${FONT_SIZE.TEXT_SM};
@@ -55,23 +58,49 @@ const checkboxWrapperStyle = css`
   }
 `;
 
-const checkboxStyle = (size: SizeTypes) => css`
-  margin: ${size === 'lg' ? '4px' : size === 'md' ? '2px' : '0px'};
-  border-radius: 50%;
+const checkboxStyle = (disabled: boolean) => css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  width: 15px;
+  height: 15px;
+  background-color: ${disabled === true ? COLOR.GRAY600 : COLOR.WHITE};
 
   svg {
     display: flex;
     align-items: center;
     justify-content: center;
     font-size: ${FONT_SIZE.TITLE_SM};
-    cursor: pointer;
-    margin: ${size === 'lg' ? '8px' : size === 'md' ? '6px' : '2px'};
   }
 
-  :hover {
-    background-color: ${COLOR_OPACITY.PRIMARY_OPACITY10};
-    transition: 0.3s;
+  .blank {
+    fill: ${disabled === true ? COLOR.GRAY600 : COLOR.BLACK};
   }
+`;
+
+const checkboxBgStyle = (size: SizeTypes, disabled: boolean) => css`
+  width: ${size === 'sm' ? '28px' : size === 'md' ? '40px' : '48px'};
+  height: ${size === 'sm' ? '28px' : size === 'md' ? '40px' : '48px'};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: ${disabled ? 'not-allowed' : 'pointer'};
+  position: relative;
+
+  ${disabled === false &&
+  css`
+    &:hover::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      border-radius: 50%;
+      background-color: ${COLOR_OPACITY.PRIMARY_OPACITY10};
+    }
+  `}
 `;
 
 export default Checkbox;

--- a/src/components/RangeSlider.tsx
+++ b/src/components/RangeSlider.tsx
@@ -1,0 +1,254 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { css } from '@emotion/react';
+import { COLOR } from '@/constants/color';
+import { FONT_SIZE } from '@/constants/font';
+
+interface RangeSliderProps {
+  min?: number;
+  max?: number;
+  step?: number;
+  defaultValues?: [number, number];
+  handleChange?: (values: [number, number]) => void;
+}
+
+const RangeSlider = ({
+  min = 0,
+  max = 100,
+  step = 10,
+  defaultValues = [min, max],
+  handleChange,
+}: RangeSliderProps) => {
+  const [values, setValues] = useState<[number, number]>(defaultValues);
+  const [isDragging, setIsDragging] = useState<'min' | 'max' | null>(null);
+  const sliderRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setValues(defaultValues);
+  }, [defaultValues]);
+
+  const getPercentage = (value: number) => ((value - min) / (max - min)) * 100;
+
+  const getValueFromPosition = (position: number) => {
+    const percentage = position / (sliderRef.current?.clientWidth || 1);
+    const value = percentage * (max - min) + min;
+    return Math.round(value / step) * step;
+  };
+
+  const handleMouseDown = (event: React.MouseEvent, type: 'min' | 'max') => {
+    setIsDragging(type);
+  };
+
+  const handleMouseUp = () => {
+    setIsDragging(null);
+  };
+
+  const handleMouseMove = useCallback(
+    (event: MouseEvent) => {
+      if (!isDragging || !sliderRef.current) return;
+
+      const sliderRect = sliderRef.current.getBoundingClientRect();
+      const position = Math.max(
+        0,
+        Math.min(event.clientX - sliderRect.left, sliderRect.width)
+      );
+      const newValue = getValueFromPosition(position);
+
+      setValues((prevValues) => {
+        let newValues: [number, number];
+        if (isDragging === 'min') {
+          newValues = [
+            Math.max(min, Math.min(newValue, prevValues[1] - step)),
+            prevValues[1],
+          ];
+        } else {
+          newValues = [
+            prevValues[0],
+            Math.min(max, Math.max(newValue, prevValues[0] + step)),
+          ];
+        }
+        handleChange?.(newValues);
+        return newValues;
+      });
+    },
+    [isDragging, step, min, max, handleChange]
+  );
+
+  useEffect(() => {
+    if (isDragging) {
+      window.addEventListener('mousemove', handleMouseMove);
+      window.addEventListener('mouseup', handleMouseUp);
+    }
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [isDragging, handleMouseMove]);
+
+  const generateTicks = useCallback(() => {
+    const ticks = [];
+    for (let i = min; i <= max; i += step) {
+      ticks.push(i);
+    }
+    return ticks;
+  }, [min, max, step]);
+
+  const Thumb = ({
+    position,
+    value,
+    type,
+  }: {
+    position: number;
+    value: number;
+    type: 'min' | 'max';
+  }) => (
+    <div
+      css={thumbStyle}
+      style={{
+        left: `${position}%`,
+      }}
+      onMouseDown={(e) => handleMouseDown(e, type)}
+    >
+      <div css={innerThumbStyle} />
+      <div css={tooltipStyle}>{value}%</div>
+    </div>
+  );
+
+  return (
+    <div css={sliderContainerStyle} ref={sliderRef}>
+      <div css={rangeInputGroupStyle}>
+        <Thumb
+          position={getPercentage(values[0])}
+          value={values[0]}
+          type='min'
+        />
+        <Thumb
+          position={getPercentage(values[1])}
+          value={values[1]}
+          type='max'
+        />
+      </div>
+
+      <div css={sliderTrackStyle}>
+        <div
+          css={sliderRangeStyle}
+          style={{
+            left: `${getPercentage(values[0])}%`,
+            width: `${getPercentage(values[1]) - getPercentage(values[0])}%`,
+          }}
+        />
+        <div css={dotsContainerStyle}>
+          {generateTicks().map((tick) => (
+            <div
+              key={tick}
+              css={dotStyle}
+              style={{
+                left: `${getPercentage(tick)}%`,
+              }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const sliderContainerStyle = css`
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 376px;
+`;
+
+const rangeInputGroupStyle = css`
+  position: relative;
+  width: 100%;
+  height: 16px;
+  margin-top: 2px;
+`;
+
+const thumbStyle = css`
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 16px;
+  height: 16px;
+  background: ${COLOR.PRIMARY};
+  border-radius: 50%;
+  cursor: pointer;
+  z-index: 10;
+`;
+
+const innerThumbStyle = css`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 4px;
+  height: 4px;
+  background: ${COLOR.WHITE};
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+`;
+
+const sliderTrackStyle = css`
+  position: absolute;
+  width: 100%;
+  height: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  border-radius: 4px;
+  background: ${COLOR.GRAY300};
+`;
+
+const dotsContainerStyle = css`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+`;
+
+const dotStyle = css`
+  position: absolute;
+  width: 4px;
+  height: 4px;
+  background: ${COLOR.WHITE};
+  border-radius: 50%;
+  z-index: 8;
+  top: 50%;
+  transform: translate(-50%, -50%);
+
+  &:nth-of-type(1) {
+    width: 16px;
+    height: 16px;
+    background: ${COLOR.GRAY300};
+  }
+
+  &:nth-last-of-type(1) {
+    width: 16px;
+    height: 16px;
+    background: ${COLOR.GRAY300};
+  }
+`;
+
+const sliderRangeStyle = css`
+  position: absolute;
+  height: 100%;
+  background: ${COLOR.PRIMARY};
+  border-radius: 4px;
+  z-index: 1;
+`;
+
+const tooltipStyle = css`
+  position: absolute;
+  background: ${COLOR.BLACK};
+  color: ${COLOR.WHITE};
+  padding: 4px 8px;
+  border-radius: 50px;
+  font-size: ${FONT_SIZE.TEXT_XS};
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 5;
+  transition: opacity 0.2s ease;
+`;
+
+export default RangeSlider;

--- a/src/components/RangeSlider.tsx
+++ b/src/components/RangeSlider.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { css } from '@emotion/react';
 import { COLOR } from '@/constants/color';
 import { FONT_SIZE } from '@/constants/font';
@@ -34,7 +34,7 @@ const RangeSlider = ({
     return Math.round(value / step) * step;
   };
 
-  const handleMouseDown = (event: React.MouseEvent, type: 'min' | 'max') => {
+  const handleMouseDown = (type: 'min' | 'max') => {
     setIsDragging(type);
   };
 
@@ -106,7 +106,7 @@ const RangeSlider = ({
       style={{
         left: `${position}%`,
       }}
-      onMouseDown={(e) => handleMouseDown(e, type)}
+      onMouseDown={() => handleMouseDown(type)}
     >
       <div css={innerThumbStyle} />
       <div css={tooltipStyle}>{value}%</div>


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

RangeSlider 컴포넌트 구현 및 체크박스 컴포넌트 수정

## 📋 작업 내용

- RangeSlider 컴포넌트 구현
- 체크박스 컴포넌트 수정 (배경이 어두울때를 위해 뒤에 흰색 박스 추가, disabled props 추가)
- 체크박스 사이즈는 sm:28, md:40, lg:48으로, 보기엔 사이즈가 같아보여도 클릭할수있는 영역의 크기가 다릅니다.

## 📸 스크린샷 
1 ) 슬라이더
![슬라이더](https://github.com/user-attachments/assets/4990a96f-fd8c-4475-8979-32e1ceebc9f7)
2 ) 체크박스
![체크박스](https://github.com/user-attachments/assets/f970433a-4fc7-4656-8066-72d7627bd851)

