### PR TITLE
[feat] Breadcrumb 컴포넌트 구현

### DIFF
--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { ChevronRight } from '@mui/icons-material';
+import { Link, useLocation } from 'react-router-dom';
+import { COLOR } from '@/constants/color';
+import { BREADCRUMB_MAP } from '@/constants/path';
+
+const Breadcrumb: React.FC = () => {
+  const { pathname } = useLocation();
+
+  const breadcrumbData =
+    BREADCRUMB_MAP[pathname] ||
+    Object.entries(BREADCRUMB_MAP).find(([key]) => {
+      const isDynamicRoute = key.includes(':');
+      if (!isDynamicRoute) return false;
+      const regex = new RegExp(`^${key.replace(/:\w+/g, '\\w+')}$`);
+      return regex.test(pathname);
+    })?.[1];
+
+  if (!breadcrumbData) return null;
+
+  return (
+    <div css={breadcrumbStyle}>
+      <div css={linksStyle}>
+        {breadcrumbData.map(({ label, path }, idx) => (
+          <React.Fragment key={label}>
+            {idx > 0 && <ChevronRight sx={{ fontSize: 24 }} />}
+            {path ? <Link to={path}>{label}</Link> : <span>{label}</span>}
+          </React.Fragment>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const breadcrumbStyle = css`
+  width: 100%;
+  height: 56px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: ${COLOR.GRAY100};
+
+  a {
+    color: ${COLOR.TEXT_BLACK};
+    text-decoration: none;
+  }
+`;
+
+const linksStyle = css`
+  width: 100%;
+  max-width: 1200px;
+  display: flex;
+  align-items: center;
+  padding: 0 10px;
+  gap: 4px;
+
+  a {
+    cursor: pointer;
+  }
+`;
+
+export default Breadcrumb;

--- a/src/constants/color.ts
+++ b/src/constants/color.ts
@@ -35,6 +35,7 @@ export const COLOR = {
 };
 
 export const COLOR_OPACITY = {
+  BLACK_OPACITY5: 'rgba(0, 0, 0, 0.05)',
   BLACK_OPACITY30: 'rgba(17, 17, 17, 0.3)',
   BLACK_OPACITY50: 'rgba(17, 17, 17, 0.5)',
   PRIMARY_OPACITY10: 'rgba(18, 97, 196, 0.1)',

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -41,6 +41,8 @@ export const PATH = {
   ADMIN_NOTICES_ADD: '/admin/notices/add',
   ADMIN_NOTICES_EDIT: (noticeId = ':noticeId') =>
     `/admin/notices/${noticeId}/edit`,
+  ADMIN_NOTICES_DETAIL: (noticeId = ':noticeId') =>
+    `/admin/notices/${noticeId}`,
   ADMIN_STRATEGIES: '/admin/strategies',
   ADMIN_METHODS: '/admin/strategies/methods',
   ADMIN_STOCKS: '/admin/strategies/stocks',
@@ -52,4 +54,127 @@ export const PATH = {
   FAQ: '/faq',
   POLICY: '/policy',
   NOT_FOUND: '*',
+};
+
+export const BREADCRUMB_MAP: {
+  [key: string]: { label: string; path?: string }[];
+} = {
+  [PATH.SIGN_FIND_ID]: [
+    { label: '계정(이메일) 찾기', path: PATH.SIGN_FIND_ID },
+  ],
+  [PATH.SIGN_FIND_PW]: [{ label: '비밀번호 재설정', path: PATH.SIGN_FIND_PW }],
+  [PATH.SIGN_UP]: [{ label: '회원가입', path: PATH.SIGN_UP }],
+  [PATH.SIGN_UP_TYPE()]: [
+    { label: '회원가입', path: PATH.SIGN_UP },
+    { label: 'STEP1. 약관동의', path: PATH.SIGN_UP_TYPE() },
+  ],
+  [PATH.SIGN_UP_FORM()]: [
+    { label: '회원가입', path: PATH.SIGN_UP },
+    { label: 'STEP2. 정보입력', path: PATH.SIGN_UP_FORM() },
+  ],
+  [PATH.SIGN_UP_DONE()]: [
+    { label: '회원가입', path: PATH.SIGN_UP },
+    { label: 'STEP3. 가입완료', path: PATH.SIGN_UP_DONE() },
+  ],
+  [PATH.STRATEGIES_LIST]: [
+    { label: '전략 탐색', path: PATH.STRATEGIES_LIST },
+    { label: '전략 목록', path: PATH.STRATEGIES_LIST },
+  ],
+  [PATH.TRADERS]: [
+    { label: '전략 탐색', path: PATH.STRATEGIES_LIST },
+    { label: '트레이더 목록', path: PATH.TRADERS },
+  ],
+  [PATH.TRADER_STRATEGIES()]: [
+    { label: '전략 탐색', path: PATH.STRATEGIES_LIST },
+    { label: '트레이더 목록', path: PATH.TRADERS },
+    { label: '전략 정보', path: PATH.TRADER_STRATEGIES() },
+  ],
+  [PATH.STRATEGIES_DETAIL()]: [
+    { label: '전략 탐색', path: PATH.STRATEGIES_LIST },
+    { label: '전략 목록', path: PATH.STRATEGIES_LIST },
+    { label: '상세 보기', path: PATH.STRATEGIES_DETAIL() },
+  ],
+  [PATH.STRATEGIES_QNA()]: [
+    { label: '전략 탐색', path: PATH.STRATEGIES_LIST },
+    { label: '전략 목록', path: PATH.STRATEGIES_LIST },
+    { label: '상세 보기', path: PATH.STRATEGIES_DETAIL() },
+    { label: '문의하기', path: PATH.STRATEGIES_QNA() },
+  ],
+  [PATH.STRATEGIES_ADD]: [{ label: '전략 등록', path: PATH.STRATEGIES_ADD }],
+  [PATH.MYPAGE]: [
+    { label: '마이페이지', path: PATH.MYPAGE },
+    { label: '내 전략', path: PATH.MYPAGE },
+  ],
+  [PATH.MYPAGE_PROFILE()]: [
+    { label: '마이페이지', path: PATH.MYPAGE },
+    { label: '내 정보 변경', path: PATH.MYPAGE_PROFILE() },
+  ],
+  [PATH.MYPAGE_PROFILE_EDIT()]: [
+    { label: '마이페이지', path: PATH.MYPAGE },
+    { label: '내 정보 변경', path: PATH.MYPAGE_PROFILE() },
+    { label: '계정정보 변경', path: PATH.MYPAGE_PROFILE_EDIT() },
+  ],
+  [PATH.MYPAGE_PASSWORD()]: [
+    { label: '마이페이지', path: PATH.MYPAGE },
+    { label: '내 정보 변경', path: PATH.MYPAGE_PROFILE() },
+    { label: '비밀번호 변경', path: PATH.MYPAGE_PASSWORD() },
+  ],
+  [PATH.MYPAGE_OPT()]: [
+    { label: '마이페이지', path: PATH.MYPAGE },
+    { label: '내 정보 변경', path: PATH.MYPAGE_PROFILE() },
+    { label: '정보 수신 동의 변경', path: PATH.MYPAGE_OPT() },
+  ],
+  [PATH.MYPAGE_QNA()]: [
+    { label: '마이페이지', path: PATH.MYPAGE },
+    { label: '상담문의', path: PATH.MYPAGE_QNA() },
+  ],
+  [PATH.MYPAGE_QNA_DETAIL()]: [
+    { label: '마이페이지', path: PATH.MYPAGE },
+    { label: '상담문의', path: PATH.MYPAGE_QNA_DETAIL() },
+  ],
+  [PATH.MYPAGE_QNA_EDIT()]: [
+    { label: '마이페이지', path: PATH.MYPAGE },
+    { label: '상담문의', path: PATH.MYPAGE_QNA() },
+    { label: '문의 글 수정', path: PATH.MYPAGE_QNA_EDIT() },
+  ],
+  [PATH.MYPAGE_WITHDRAW]: [
+    { label: '마이페이지', path: PATH.MYPAGE },
+    { label: '내 정보 변경', path: PATH.MYPAGE_PROFILE() },
+    { label: '회원 탈퇴', path: PATH.MYPAGE_WITHDRAW },
+  ],
+  [PATH.MYPAGE_STRATEGIES_EDIT()]: [
+    { label: '마이페이지', path: PATH.MYPAGE },
+    { label: '내 전략', path: PATH.MYPAGE },
+    { label: '전략 수정', path: PATH.MYPAGE_STRATEGIES_EDIT() },
+  ],
+  [PATH.ADMIN_USERS]: [{ label: '회원 관리', path: PATH.ADMIN_USERS }],
+  [PATH.ADMIN_NOTICES]: [{ label: '공지 관리', path: PATH.ADMIN_NOTICES }],
+  [PATH.ADMIN_NOTICES_ADD]: [
+    { label: '공지 관리', path: PATH.ADMIN_NOTICES },
+    { label: '공지 작성', path: PATH.ADMIN_NOTICES_ADD },
+  ],
+  [PATH.ADMIN_NOTICES_EDIT()]: [
+    { label: '공지 관리', path: PATH.ADMIN_NOTICES },
+    { label: '공지 수정', path: PATH.ADMIN_NOTICES_EDIT() },
+  ],
+  [PATH.ADMIN_NOTICES_DETAIL()]: [
+    { label: '공지 관리', path: PATH.ADMIN_NOTICES },
+  ],
+  [PATH.ADMIN_STRATEGIES]: [
+    { label: '전략 관리', path: PATH.ADMIN_STRATEGIES },
+    { label: '전략 목록', path: PATH.ADMIN_STRATEGIES },
+  ],
+  [PATH.ADMIN_METHODS]: [
+    { label: '전략 관리', path: PATH.ADMIN_STRATEGIES },
+    { label: '매매방식 관리', path: PATH.ADMIN_METHODS },
+  ],
+  [PATH.ADMIN_STOCKS]: [
+    { label: '전략 관리', path: PATH.ADMIN_STRATEGIES },
+    { label: '종목 관리', path: PATH.ADMIN_STOCKS },
+  ],
+  [PATH.ADMIN_QNA]: [{ label: '문의 관리', path: PATH.ADMIN_QNA }],
+  [PATH.NOTICES]: [{ label: '공지사항', path: PATH.NOTICES }],
+  [PATH.NOTICES_DETAIL()]: [{ label: '공지사항', path: PATH.NOTICES_DETAIL() }],
+  [PATH.FAQ]: [{ label: '자주 묻는 질문', path: PATH.FAQ }],
+  [PATH.POLICY]: [{ label: '개인정보처리방침', path: PATH.POLICY }],
 };

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -1,38 +1,49 @@
 import { css } from '@emotion/react';
 import { Link } from 'react-router-dom';
 import logo from '@/assets/images/logo.png';
-import { COLOR } from '@/constants/color';
+import Breadcrumb from '@/components/Breadcrumb';
+import { COLOR, COLOR_OPACITY } from '@/constants/color';
 import { FONT_WEIGHT } from '@/constants/font';
 import { PATH } from '@/constants/path';
 
 const Header = () => (
   <header css={wrapperStyle}>
-    <div css={headerTopBgStyle}>
-      <div css={headerTopStyle}>
-        <div className='top-links'>
-          <Link to={PATH.SIGN_UP}>회원가입</Link>
-          <Link to={PATH.SIGN_IN}>로그인</Link>
+    <div css={headerStyle}>
+      <div css={headerTopBgStyle}>
+        <div css={headerTopStyle}>
+          <div className='top-links'>
+            <Link to={PATH.SIGN_UP}>회원가입</Link>
+            <Link to={PATH.SIGN_IN}>로그인</Link>
+          </div>
+        </div>
+      </div>
+      <div css={headerBottomStyle}>
+        <Link to={PATH.ROOT}>
+          <img className='bottom-logo' src={logo} />
+        </Link>
+        <div className='bottom-links'>
+          <Link to={PATH.STRATEGIES_LIST}>전략탐색</Link>
+          <Link to={PATH.STRATEGIES_ADD}>전략등록</Link>
+          <Link to={PATH.NOTICES}>공지사항</Link>
+          <Link to={PATH.FAQ}>자주묻는질문</Link>
         </div>
       </div>
     </div>
-    <div css={headerBottomStyle}>
-      <Link to={PATH.ROOT}>
-        <img className='bottom-logo' src={logo} />
-      </Link>
-      <div className='bottom-links'>
-        <Link to={PATH.STRATEGIES_LIST}>전략탐색</Link>
-        <Link to={PATH.STRATEGIES_ADD}>전략등록</Link>
-        <Link to={PATH.NOTICES}>공지사항</Link>
-        <Link to={PATH.FAQ}>자주묻는질문</Link>
-      </div>
-    </div>
+    <Breadcrumb />
   </header>
 );
 
 const wrapperStyle = css`
   width: 100%;
   margin: 0 auto;
-  box-shadow: 0px 4px 2px 0px #0000000d;
+`;
+
+const headerStyle = css`
+  width: 100%;
+  height: 100%;
+  position: relative;
+  margin: 0 auto;
+  box-shadow: 0px 4px 2px 0px ${COLOR_OPACITY.BLACK_OPACITY5};
 `;
 
 const headerTopBgStyle = css`

--- a/src/pages/admin/AdminNoticesDetail.tsx
+++ b/src/pages/admin/AdminNoticesDetail.tsx
@@ -1,0 +1,3 @@
+const AdminNoticesDetail = () => <div>AdminNoticesDetail</div>;
+
+export default AdminNoticesDetail;

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -11,6 +11,7 @@ import AdminMethods from '@/pages/admin/AdminMethods';
 import AdminNoticeAdd from '@/pages/admin/AdminNoticeAdd';
 import AdminNoticeEdit from '@/pages/admin/AdminNoticeEdit';
 import AdminNotices from '@/pages/admin/AdminNotices';
+import AdminNoticesDetail from '@/pages/admin/AdminNoticesDetail';
 import AdminQna from '@/pages/admin/AdminQna';
 import AdminStocks from '@/pages/admin/AdminStocks';
 import AdminStrategies from '@/pages/admin/AdminStrategies';
@@ -214,6 +215,10 @@ const router = createBrowserRouter([
       {
         path: PATH.ADMIN_NOTICES_EDIT(),
         element: <AdminNoticeEdit />,
+      },
+      {
+        path: PATH.ADMIN_NOTICES_DETAIL(),
+        element: <AdminNoticesDetail />,
       },
       {
         path: PATH.ADMIN_STRATEGIES_CONTROL(),


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

Breadcrumb 컴포넌트 구현

## 📋 작업 내용

- Breadcrumb 컴포넌트 배경 색상 color 상수 파일에 추가
- Breadcrumb 컴포넌트 구현
- Header 레이아웃에 Breadcrumb 적용
- 라우팅 수정사항 반영

## 📸 스크린샷 (선택 사항)
### 📌 Breadcrumb 컴포넌트
![ex](https://github.com/user-attachments/assets/4672bb30-d1b3-4464-812e-30632334c05f)

## 📄 기타

추가적으로, 관리자 공지사항 상세보기 페이지 파일을 생성하고 라우팅 및 path 파일에 반영했습니다.